### PR TITLE
Enable external modifications to theme TailwindCSS config before load

### DIFF
--- a/assets/config/tailwind.config.js
+++ b/assets/config/tailwind.config.js
@@ -16,5 +16,6 @@ module.exports = {
       },
     },
     plugins: [],
+    variants: ['group-hover'],
   }
   


### PR DESCRIPTION
I attempted to find a way to merge my change from a local config into the theme's, but this would require an upstream change anyway. I would prefer to enable someone to merge their custom tailwindcss config from outside the theme, but I'm not sure how you might want to approach this. Suggestions?

My use case: When using :hover attached to elements in a 'group', the hover will not trigger unless this variant is added to the config. (See example: https://stackoverflow.com/questions/63266702/tailwindcss-group-hover-not-working-on-border-color)

This PR represents the final result I would like to see in the config before it's loaded.

(sorry for the noisy PRs... thx for the theme!)