### PR TITLE
Add missing submodule add command to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 - Open a Terminal and navigate to the root directory of your Hugo site. Then, run the following command to add the theme as a submodule to your site's git repository:
 ```
 git init
-git submodule https://github.com/nixentric/Lowkey-Hugo-Theme.git themes/lowkey
+git submodule add https://github.com/nixentric/Lowkey-Hugo-Theme.git themes/lowkey
 ```
 - Delete `config.toml`
 - Copy all of the ExampleSite's files and directories into the root directory of your Hugo site, overwriting any existing files with the same names.


### PR DESCRIPTION
I tried to install the submodule with `git submodule https://github.com/nixentric/Lowkey-Hugo-Theme.git themes/lowkey` however it seems like the correct command is `git submodule add https://github.com/nixentric/Lowkey-Hugo-Theme.git themes/lowkey` which is the fix I made here.