### PR TITLE
Fix: Use i18n for summary

### DIFF
--- a/ExampleSite/i18n/en.toml
+++ b/ExampleSite/i18n/en.toml
@@ -4,6 +4,9 @@
 [readMore]
     other = 'Read more'
 
+[summary]
+    other = 'Summary'
+
 [404_title]
     other = 'Page not found'
 

--- a/ExampleSite/i18n/pt.toml
+++ b/ExampleSite/i18n/pt.toml
@@ -4,6 +4,9 @@
 [readMore]
     other = 'Ler mais'
 
+[summary]
+    other = 'Sumário'
+
 [404_title]
     other = 'Página não encontrada'
 

--- a/layouts/partials/single/table-of-contents.html
+++ b/layouts/partials/single/table-of-contents.html
@@ -1,6 +1,6 @@
 {{ if and .TableOfContents .Params.tableOfContents }}
   <aside class="table-of-contents">
-    <h2 class="title-small">Sumário</h2>
+    <h2 class="title-small">{{ i18n "summary" }}</h2>
     {{ .TableOfContents }}
   </aside>
 {{ end }}


### PR DESCRIPTION
Summary was hard-coded as `Sumário`, I've changed this to make use of i18n.