### PR TITLE
Fix: Add padding

### DIFF
--- a/ExampleSite/i18n/en.toml
+++ b/ExampleSite/i18n/en.toml
@@ -7,6 +7,9 @@
 [summary]
     other = 'Summary'
 
+[estimatedReadingTime]
+    other = 'Estimated reading time: %d minutes'
+
 [404_title]
     other = 'Page not found'
 

--- a/ExampleSite/i18n/en.toml
+++ b/ExampleSite/i18n/en.toml
@@ -4,6 +4,9 @@
 [readMore]
     other = 'Read more'
 
+[summary]
+    other = 'Summary'
+
 [404_title]
     other = 'Page not found'
 

--- a/ExampleSite/i18n/pt.toml
+++ b/ExampleSite/i18n/pt.toml
@@ -4,6 +4,9 @@
 [readMore]
     other = 'Ler mais'
 
+[summary]
+    other = 'Sumário'
+
 [404_title]
     other = 'Página não encontrada'
 

--- a/ExampleSite/i18n/pt.toml
+++ b/ExampleSite/i18n/pt.toml
@@ -7,6 +7,9 @@
 [summary]
     other = 'Sumário'
 
+[estimatedReadingTime]
+    other = 'Tempo estimado de leitura: %d minutos'
+
 [404_title]
     other = 'Página não encontrada'
 

--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -103,7 +103,7 @@
   }
 
   body {
-    @apply bg-white dark:bg-gray-900 text-gray-700 dark:text-gray-300 text-lg text-justify;
+    @apply bg-white dark:bg-gray-900 text-gray-700 dark:text-gray-300 text-lg text-justify px-4;
   }
   
   h1, h2, h3, h4, h5, h6 {

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -7,7 +7,7 @@
     <div class="meta">
       {{/* Publish date */}}
       <time datetime="{{ .PublishDate }}" title='{{ .PublishDate.Format "Mon, Jan 2, 2006, 3:04 PM MST" }}'>
-        {{ .PublishDate.Format "02/01/2006" }} - {{ printf i18n "estimatedReadingTime" .ReadingTime }}
+        {{ .PublishDate.Format "02/01/2006" }} - {{ printf (i18n "estimatedReadingTime") .ReadingTime }}
       </time>
 
       {{/* Categories */}} 

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -7,7 +7,7 @@
     <div class="meta">
       {{/* Publish date */}}
       <time datetime="{{ .PublishDate }}" title='{{ .PublishDate.Format "Mon, Jan 2, 2006, 3:04 PM MST" }}'>
-        {{ .PublishDate.Format "02/01/2006" }}
+        {{ .PublishDate.Format "02/01/2006" }} - {{ printf i18n "estimatedReadingTime" .ReadingTime }}
       </time>
 
       {{/* Categories */}} 

--- a/layouts/partials/single/table-of-contents.html
+++ b/layouts/partials/single/table-of-contents.html
@@ -1,6 +1,6 @@
 {{ if and .TableOfContents .Params.tableOfContents }}
   <aside class="table-of-contents">
-    <h2 class="title-small">Sumário</h2>
+    <h2 class="title-small">{{ i18n "summary" }}</h2>
     {{ .TableOfContents }}
   </aside>
 {{ end }}


### PR DESCRIPTION
On mobile devices it looked pretty weird as there was 0 padding, because of that the text would hit the sides. This was also the case for non-mobile devices with a small screen. This PR fixes that by adding a horizontal padding of 4.