### PR TITLE
feat: add script for google analytics

### DIFF
--- a/layouts/partials/head/meta.html
+++ b/layouts/partials/head/meta.html
@@ -1,11 +1,30 @@
-{{ $favicon := resources.GetMatch .Site.Params.favicon }} 
+{{ $favicon := resources.GetMatch .Site.Params.favicon }}
 
-<meta charset="UTF-8">
-<meta http-equiv="X-UA-Compatible" content="IE=edge">
-<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta charset="UTF-8" />
+<meta http-equiv="X-UA-Compatible" content="IE=edge" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 <title>{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ .Title }}{{ end }}</title>
-<meta name="description" content="{{ if .IsPage }}{{ or .Params.description .Summary }}{{ else if .IsHome }}{{ .Site.Params.description }}{{ else if .IsNode }}{{ or .Params.description .Summary }}{{ end }}">
-<link rel="canonical" href="{{ .Permalink }}">
+<meta
+  name="description"
+  content="{{ if .IsPage }}{{ or .Params.description .Summary }}{{ else if .IsHome }}{{ .Site.Params.description }}{{ else if .IsNode }}{{ or .Params.description .Summary }}{{ end }}"
+/>
+<link rel="canonical" href="{{ .Permalink }}" />
 <link rel="robots" href="/robots.txt" />
 
-<link rel="icon" type="image/x-icon" href="{{ $favicon.RelPermalink }}">
+<link rel="icon" type="image/x-icon" href="{{ $favicon.RelPermalink }}" />
+
+<!-- Google Analytics -->
+<script
+  defer
+  src="https://www.googletagmanager.com/gtag/js?id={{ .Site.GoogleAnalytics }}"
+></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag() {
+    dataLayer.push(arguments);
+  }
+  gtag('js', new Date());
+
+  gtag('config', '{{ .Site.GoogleAnalytics }}');
+</script>
+<!-- End Google Analytics -->


### PR DESCRIPTION
I was trying to understand why my blog no longer records analytics data after migrating to the Lowkey theme, I realized that the theme did not have the analytics script.

Even adding `googleAnalytics` to `hugo.toml` had no effect, as it was not used anywhere.

So I added the script to `meta.html` and the analytics worked as it should.