### PR TITLE
Only load Google Analytics snippet if a corresponding ID is defined

### DIFF
--- a/layouts/partials/head/meta.html
+++ b/layouts/partials/head/meta.html
@@ -13,6 +13,7 @@
 
 <link rel="icon" type="image/x-icon" href="{{ $favicon.RelPermalink }}" />
 
+{{ if .Site.GoogleAnalytics}}
 <!-- Google Analytics -->
 <script
   defer
@@ -28,3 +29,4 @@
   gtag('config', '{{ .Site.GoogleAnalytics }}');
 </script>
 <!-- End Google Analytics -->
+{{ end }}


### PR DESCRIPTION
The Google Analytics snippet is being injected into the website's `<head>` regardless of if the user has opted to use the service or not; this patch only loads the snippet if a Google Analytics ID has been defined in the settings.

This ensures GDPR compliance for users that have not opted-in to Google Analytics as the URL is not pinged unless the user has explicitly provided a Google Analytics ID in the website's configuration files.