### PR TITLE
Fix deprecation errors hindering build

### DIFF
--- a/layouts/partials/head/meta.html
+++ b/layouts/partials/head/meta.html
@@ -13,11 +13,11 @@
 
 <link rel="icon" type="image/x-icon" href="{{ $favicon.RelPermalink }}" />
 
-{{ if .Site.GoogleAnalytics}}
+{{ if .Site.Config.Services.GoogleAnalytics.ID }}
 <!-- Google Analytics -->
 <script
   defer
-  src="https://www.googletagmanager.com/gtag/js?id={{ .Site.GoogleAnalytics }}"
+  src="https://www.googletagmanager.com/gtag/js?id={{ .Site.Config.Services.GoogleAnalytics.ID }}"
 ></script>
 <script>
   window.dataLayer = window.dataLayer || [];
@@ -26,7 +26,7 @@
   }
   gtag('js', new Date());
 
-  gtag('config', '{{ .Site.GoogleAnalytics }}');
+  gtag('config', '{{ .Site.Config.Services.GoogleAnalytics.ID }}');
 </script>
 <!-- End Google Analytics -->
 {{ end }}


### PR DESCRIPTION
Hello,

I followed the setup guide and ran `hugo server` on Ubuntu 24.04/Hugo v0.135.0-extended, but it failed with a deprecation error:
```
ERROR deprecated: .Site.GoogleAnalytics was deprecated in Hugo v0.120.0 and will be removed in Hugo 0.136.0. Use .Site.Config.Services.GoogleAnalytics.ID instead.
```

Here's the complete version string (`hugo version`):
```
hugo v0.135.0-f30603c47f5205e30ef83c70419f57d7eb7175ab+extended linux/amd64 BuildDate=2024-09-27T13:17:08Z VendorInfo=snap:0.135.0
```

After applying the patch suggested in this PR, the build succeeded.