### PR TITLE
use commonJS syntax

### DIFF
--- a/config/tailwind.config.js
+++ b/config/tailwind.config.js
@@ -1,4 +1,4 @@
-import path from 'path';
+const path = require('path');
 
 // When deploying to production, set the base directory to your Hugo project's root directory.
 const baseDir = path.join(__dirname, '..');


### PR DESCRIPTION
Hello,

I followed the instructions in the README with a fresh local folder.

```
mkdir testblod && cd testblog
git init
git submodule add https://github.com/nixentric/Lowkey-Hugo-Theme.git themes/enchanted-lowkey
cp -R themes/enchanted-lowkey/ExampleSite/. .
npm install
```

However, when I went to run `hugo server`, I got the following error:
```
% hugo server
WARN  deprecated: site config key paginate was deprecated in Hugo v0.128.0 and will be removed in a future release. Use pagination.pagerSize instead.
Watching for changes in /Users/melina/projects/testblog/{content,i18n,package.json,themes}
Watching for config changes in /Users/melina/projects/testblog/config/_default
Start building sites … 
hugo v0.137.1+extended darwin/arm64 BuildDate=2024-11-05T11:49:09Z VendorInfo=brew

Built in 1011 ms
Error: error building site: POSTCSS: failed to transform "/css/tailwind.css" (text/css): (node:35445) ExperimentalWarning: CommonJS module /Users/melina/projects/testblog/node_modules/tailwindcss/lib/lib/load-config.js is loading ES Module /Users/melina/projects/testblog/themes/enchanted-lowkey/config/tailwind.config.js using require().
Support for loading ES Module in require() is an experimental feature and might change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
file:///Users/melina/projects/testblog/themes/enchanted-lowkey/config/tailwind.config.js:4
const baseDir = path.join(__dirname, '..');
                          ^

ReferenceError: __dirname is not defined
    at file:///Users/melina/projects/testblog/themes/enchanted-lowkey/config/tailwind.config.js:4:27
    at ModuleJobSync.runSync (node:internal/modules/esm/module_job:367:35)
    at ModuleLoader.importSyncForRequire (node:internal/modules/esm/loader:325:47)
    at loadESMFromCJS (node:internal/modules/cjs/loader:1396:24)
    at Module._compile (node:internal/modules/cjs/loader:1529:5)
    at Object..js (node:internal/modules/cjs/loader:1709:10)
    at Module.load (node:internal/modules/cjs/loader:1315:32)
    at Function._load (node:internal/modules/cjs/loader:1125:12)
    at TracingChannel.traceSync (node:diagnostics_channel:322:14)
    at wrapModuleLoad (node:internal/modules/cjs/loader:216:24)

Node.js v23.1.0
```

```
% npm -v
10.9.0
```

Ultimately, the issue is that the `tailwind` package added support for ES Modules in May 2023 https://github.com/tailwindlabs/tailwindcss/discussions/5858#discussioncomment-5470534

Perhaps your devs are using old `tailwind` versions to build, because with this new support, the first line of `tailwind.config.js` was being detected as the entire file being an ES Module.
```
import path from 'path';
```

The fix is to convert this back to CommonJS syntax.
```
const path = require('path');
```

After making that change, the hugo server starts properly.
```
% hugo server
WARN  deprecated: site config key paginate was deprecated in Hugo v0.128.0 and will be removed in a future release. Use pagination.pagerSize instead.
Watching for changes in /Users/melina/projects/testblog/{content,i18n,package.json,themes}
Watching for config changes in /Users/melina/projects/testblog/config/_default
Start building sites … 
hugo v0.137.1+extended darwin/arm64 BuildDate=2024-11-05T11:49:09Z VendorInfo=brew


                   | EN  
-------------------+-----
  Pages            | 24  
  Paginator pages  |  0  
  Non-page files   |  1  
  Static files     | 18  
  Processed images |  1  
  Aliases          |  7  
  Cleaned          |  0  

Built in 985 ms
Environment: "development"
Serving pages from disk
Running in Fast Render Mode. For full rebuilds on change: hugo server --disableFastRender
Web Server is available at http://localhost:1313/ (bind address 127.0.0.1) 
Press Ctrl+C to stop
```