### PR TITLE
Adding padding to improve mobile view

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -4,7 +4,7 @@
     {{- partial "head/index" . -}}
   </head>
 
-  <body class="max-w-screen-md mx-auto">
+  <body class="max-w-screen-md mx-auto px-2.5">
     <div class="header">
       {{ partial "header/index" . }}
       {{ partial "header/theme-button" . }}


### PR DESCRIPTION
Adding a small padding to improve mobile view.

See before and after screenshots.

Potentially fixing issue #33 

*Before:*
![mobile_view_before](https://github.com/user-attachments/assets/a4172d25-8a1e-4a77-8d86-602e0f6ca67d)

*After:*
![mobile_view_after](https://github.com/user-attachments/assets/50dd77c9-1a92-4b46-8c15-1dff1b2955f9)
