### PR TITLE
Change submodule URL to use SSH format

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ And also to the other contributors 💌:
 - Open a Terminal and navigate to the root directory of your Hugo site. Then, run the following command to add the theme as a submodule to your site's git repository:
 ```
 git init
-git submodule add https://github.com/nixentric/Lowkey-Hugo-Theme.git themes/enchanted-lowkey
+git submodule add git@github.com:nixentric/Lowkey-Hugo-Theme.git themes/enchanted-lowkey
 ```
 - Delete `config.toml` / `hugo.toml`
 - Copy all of the ExampleSite's files and directories into the root directory of your Hugo site, overwriting any existing files with the same names.


### PR DESCRIPTION
HTTPS clone is deprecated now, so change clone method to ssh is better for beginners to start to learn Hugo and this theme